### PR TITLE
Tarefa 4 - IPs by authors and tests

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -25,6 +25,21 @@ class PostsController < ApplicationController
     render json: posts.as_json(only: [ :id, :title, :body ])
   end
 
+  def ips_by_authors
+    posts = Post
+              .includes(:user)
+              .group_by(&:ip)
+
+    result = posts.map do |ip, posts_group|
+      {
+        ip: ip,
+        logins: posts_group.map { |post| post.user.login }.uniq
+      }
+    end
+
+    render json: result
+  end
+
   private
 
   def set_user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   resources :posts, only: [ :create ] do
     collection do
       get :top_posts
+      get :ips_by_authors
     end
   end
   resources :ratings, only: [ :create ]

--- a/spec/requests/posts/ips_by_authors_spec.rb
+++ b/spec/requests/posts/ips_by_authors_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "Posts", type: :request do
+    describe "GET /posts/ips_by_authors" do
+        let!(:user1) { create(:user, login: "user1") }
+        let!(:user2) { create(:user, login: "user2") }
+        let!(:user3) { create(:user, login: "user3") }
+
+        let!(:post1) { create(:post, user: user1, ip: "192.168.1.1") }
+        let!(:post2) { create(:post, user: user2, ip: "192.168.1.1") }
+        let!(:post3) { create(:post, user: user3, ip: "10.0.0.1") }
+        let!(:post4) { create(:post, user: user1, ip: "10.0.0.1") }
+
+        it "returns a list of IPs with associated user logins" do
+          get "/posts/ips_by_authors"
+
+          expect(response).to have_http_status(:success)
+
+          json = JSON.parse(response.body)
+
+          expect(json).to include(
+            a_hash_including(
+              "ip" => "192.168.1.1",
+              "logins" => match_array([ "user1", "user2" ])
+            ),
+            a_hash_including(
+              "ip" => "10.0.0.1",
+              "logins" => match_array([ "user1", "user3" ])
+            )
+          )
+        end
+    end
+end


### PR DESCRIPTION
Implementa a funcionalidade para listar os IPs usados por diferentes autores em seus posts.

Pincipais mudanças:

- Implementação do método ips_by_authors no post controller
- Endpoint GET /posts/ips_by_authors 
- Retorna um array de objetos contendo o IP utilizado e uma lista de logins dos usuários que publicaram usando esse IP.
- Teste de request de ips_by_authors no post controller.